### PR TITLE
FIX : AddNode 결과로 Node의 Cluster 소속 변경 시 Node가 중복으로 존재하게 되는 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,9 @@ on:
       - '.github/workflows/deploy.yml'
       - 'ecs/**'
       - 'src/**'
+      - 'scripts/**'
       - 'Dockerfile'
+      - 'entrypoint.sh'
       - 'package*.json'
       - 'prisma/**'
 
@@ -86,6 +88,7 @@ jobs:
           task-definition: ecs/worker-task-definition.json
           container-name: taco5_graphnode_worker_container
           image: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
+
         # Amazon ECS 서비스에 새 작업 정의 배포 (API)
       - name: Deploy Amazon ECS task definition (API)
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN npx prisma generate
 # 나머지 소스 코드 복사
 COPY . .
 RUN npm run build
+# scripts/ 폴더를 tsconfig.scripts.json으로 별도 컴파일 → dist/scripts/*.js 생성
+RUN npx tsc --project tsconfig.scripts.json
 
 # ---- runner ----
 FROM node:20-alpine AS runner

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,5 +14,16 @@ fi
 echo "Regenerating Prisma Client..."
 npx prisma generate
 
+# Run Neo4j BELONGS_TO dedup migration (idempotent, non-fatal)
+# 중복 BELONGS_TO 관계 정리 + Ghost Cluster 삭제
+# - 이미 정리된 DB에서는 대상 없이 즉시 종료 (멱등성 보장)
+# - API/Worker 컨테이너가 동시에 실행해도 Neo4j 트랜잭션이 ACID를 보장하므로 안전
+echo "Running Neo4j BELONGS_TO dedup migration..."
+if [ -n "$NEO4J_URI" ]; then
+  node dist/scripts/migrate-dedup-belongs-to.js || echo "⚠ Neo4j migration failed (non-fatal, server will start anyway)"
+else
+  echo "NEO4J_URI not set, skipping Neo4j migration."
+fi
+
 # Start the application
 exec "$@"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "k6:users:delete": "tsx tests/scripts/delete-k6-users.ts",
     "k6:smoke:managed": "tsx tests/scripts/run-k6-smoke-managed.ts",
     "migrate:neo4j": "tsx scripts/sync-macro-graph.ts",
-    "migrate:neo4j:dry": "tsx scripts/sync-macro-graph.ts --dry-run"
+    "migrate:neo4j:dry": "tsx scripts/sync-macro-graph.ts --dry-run",
+    "migrate:neo4j:dedup": "tsx scripts/migrate-dedup-belongs-to.ts",
+    "migrate:neo4j:dedup:dry": "tsx scripts/migrate-dedup-belongs-to.ts --dry-run",
+    "build:scripts": "tsc --project tsconfig.scripts.json"
   },
   "repository": {
     "type": "git",

--- a/scripts/migrate-dedup-belongs-to.ts
+++ b/scripts/migrate-dedup-belongs-to.ts
@@ -1,0 +1,200 @@
+/**
+ * scripts/migrate-dedup-belongs-to.ts
+ *
+ * Neo4j MacroNode BELONGS_TO 중복 관계 정리 + Ghost Cluster 삭제 마이그레이션
+ *
+ * 동작:
+ *  1. Neo4j에서 MacroGraph 노드 전체를 조회해 대상 userId 목록을 동적으로 추출
+ *  2. 각 사용자에 대해 deduplicateBelongsTo → removeEmptyClusters 순으로 실행
+ *  3. --dry-run 플래그 시 실제 DELETE 없이 영향 범위(카운트)만 출력
+ *  4. 이미 정리된 DB에서 실행하면 변경 없이 빠르게 종료 (멱등성 보장)
+ *
+ * 실행 방법:
+ *  node dist/scripts/migrate-dedup-belongs-to.js
+ *  node dist/scripts/migrate-dedup-belongs-to.js --dry-run
+ *  node dist/scripts/migrate-dedup-belongs-to.js --userId=<id>
+ *
+ * 환경변수 (직접 주입 또는 .env):
+ *  NEO4J_URI      - neo4j+s://... 형식
+ *  NEO4J_USERNAME
+ *  NEO4J_PASSWORD
+ */
+
+import { initNeo4j, closeNeo4j, getNeo4jDriver } from '../src/infra/db/neo4j';
+import { Neo4jMacroGraphAdapter } from '../src/infra/graph/Neo4jMacroGraphAdapter';
+
+// ──────────────────────────────────────────────────────────────
+// 인터페이스
+// ──────────────────────────────────────────────────────────────
+
+interface MigrationResult {
+  userId: string;
+  success: boolean;
+  /** dry-run 시 삭제 예정 관계 수 */
+  excessRelCount?: number;
+  /** dry-run 시 중복 보유 노드 수 */
+  duplicateNodeCount?: number;
+  /** 실제 실행 시 삭제된 ghost cluster 판단을 위한 마커 */
+  cleaned?: boolean;
+  error?: string;
+  durationMs: number;
+}
+
+// ──────────────────────────────────────────────────────────────
+// 메인
+// ──────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const isDryRun = args.includes('--dry-run');
+  const singleUser = args.find((a) => a.startsWith('--userId='))?.split('=')[1];
+
+  console.log('========================================================');
+  console.log('  Neo4j BELONGS_TO Dedup Migration');
+  console.log('========================================================');
+  console.log(`모드: ${isDryRun ? '🔍 DRY RUN (읽기 전용)' : '🚀 실제 마이그레이션'}`);
+  console.log(`Neo4j URI: ${process.env['NEO4J_URI'] ?? '(env 미설정)'}`);
+  console.log('');
+
+  // Neo4j 연결
+  try {
+    await initNeo4j();
+    console.log('[Neo4j] 연결 성공');
+  } catch (err) {
+    console.error('[Neo4j] 연결 실패:', err);
+    process.exit(1);
+  }
+
+  const adapter = new Neo4jMacroGraphAdapter();
+
+  // 대상 userId 수집
+  let userIds: string[];
+  if (singleUser) {
+    userIds = [singleUser];
+    console.log(`대상 사용자: 단일 지정 → ${singleUser}`);
+  } else {
+    const driver = getNeo4jDriver();
+    const session = driver.session();
+    try {
+      const result = await session.run('MATCH (g:MacroGraph) RETURN g.userId AS userId');
+      userIds = result.records.map((r) => String(r.get('userId') ?? '')).filter(Boolean);
+    } finally {
+      await session.close();
+    }
+    console.log(`대상 사용자: DB 동적 조회 → ${userIds.length}명`);
+  }
+
+  if (userIds.length === 0) {
+    console.log('⚠️  대상 사용자 없음. 종료합니다.');
+    await closeNeo4j();
+    return;
+  }
+
+  console.log('');
+
+  // 사용자별 마이그레이션 실행
+  const results: MigrationResult[] = [];
+
+  for (const userId of userIds) {
+    const startMs = Date.now();
+    const shortId = userId.slice(0, 8);
+    console.log(`[${shortId}...] 시작`);
+
+    try {
+      if (isDryRun) {
+        // dry-run: 카운트만 조회
+        const { duplicateNodeCount, excessRelCount } =
+          await adapter.countDuplicateBelongsTo(userId);
+
+        const durationMs = Date.now() - startMs;
+
+        if (duplicateNodeCount === 0) {
+          console.log(`  ✅ 중복 없음 (${durationMs}ms)`);
+        } else {
+          console.log(
+            `  ⚠️  중복 노드: ${duplicateNodeCount}개, 삭제 예정 관계: ${excessRelCount}개 (${durationMs}ms)`
+          );
+        }
+
+        results.push({
+          userId,
+          success: true,
+          duplicateNodeCount,
+          excessRelCount,
+          durationMs,
+        });
+      } else {
+        // 실제 실행
+        // 1단계: 중복 BELONGS_TO 정리
+        await adapter.deduplicateBelongsTo(userId);
+
+        // 2단계: Ghost Cluster 정리
+        await adapter.removeEmptyClusters(userId);
+
+        const durationMs = Date.now() - startMs;
+        console.log(`  ✅ 완료 (${durationMs}ms)`);
+
+        results.push({ userId, success: true, cleaned: true, durationMs });
+      }
+    } catch (err) {
+      const durationMs = Date.now() - startMs;
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      console.error(`  ❌ 실패: ${errorMessage}`);
+      results.push({ userId, success: false, error: errorMessage, durationMs });
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────
+  // 결과 요약
+  // ──────────────────────────────────────────────────────────────
+  console.log('');
+  console.log('========================================================');
+  console.log('  마이그레이션 결과 요약');
+  console.log('========================================================');
+
+  const successes = results.filter((r) => r.success);
+  const failures = results.filter((r) => !r.success);
+
+  console.log(`성공: ${successes.length}명 / 실패: ${failures.length}명`);
+  console.log('');
+
+  if (isDryRun) {
+    const totalDuplicateNodes = successes.reduce((s, r) => s + (r.duplicateNodeCount ?? 0), 0);
+    const totalExcessRels = successes.reduce((s, r) => s + (r.excessRelCount ?? 0), 0);
+    console.log(`[DRY RUN 요약]`);
+    console.log(`  전체 중복 노드: ${totalDuplicateNodes}개`);
+    console.log(`  전체 삭제 예정 BELONGS_TO: ${totalExcessRels}개`);
+    console.log('');
+    console.log('실제 정리를 실행하려면 --dry-run 플래그를 제거하세요.');
+  } else {
+    console.log('사용자별 상세:');
+    for (const r of results) {
+      const icon = r.success ? '✅' : '❌';
+      const detail = r.success
+        ? `정리 완료 (${r.durationMs}ms)`
+        : `ERROR: ${r.error} (${r.durationMs}ms)`;
+      console.log(`  ${icon} ${r.userId.slice(0, 8)}... → ${detail}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.log('');
+    console.log('⚠️  실패한 사용자는 아래 명령으로 재시도하세요:');
+    failures.forEach((r) => console.log(`  --userId=${r.userId}`));
+  }
+
+  // 정리
+  await closeNeo4j();
+  console.log('');
+  console.log('[완료] Neo4j 연결 종료');
+
+  // 실패가 있으면 비-0 exit code로 CI에서 감지 가능
+  if (failures.length > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error('FATAL:', err);
+  process.exit(1);
+});

--- a/src/core/ports/MacroGraphStore.ts
+++ b/src/core/ports/MacroGraphStore.ts
@@ -817,6 +817,31 @@ export interface MacroGraphStore {
    * @param options transaction 등 adapter 전용 옵션
    */
   removeEmptyClusters(userId: string, options?: MacroGraphStoreOptions): Promise<void>;
+
+  /**
+   * @description 한 MacroNode에 BELONGS_TO 관계가 복수 개 누적된 경우 중복을 정리합니다.
+   *
+   * clusterId의 숫자 파트가 가장 큰 클러스터(가장 최신 AI 결정)를 유지하고
+   * 나머지 BELONGS_TO 관계를 모두 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options transaction 등 adapter 전용 옵션
+   */
+  deduplicateBelongsTo(userId: string, options?: MacroGraphStoreOptions): Promise<void>;
+
+  /**
+   * @description dry-run 전용 — 중복 BELONGS_TO를 보유한 노드 수와 초과 관계 수를 반환합니다.
+   *
+   * 실제 DELETE 없이 `deduplicateBelongsTo` 실행 시 영향 범위만 미리 확인합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options transaction 등 adapter 전용 옵션
+   * @returns duplicateNodeCount (중복 보유 노드 수), excessRelCount (삭제될 관계 수)
+   */
+  countDuplicateBelongsTo(
+    userId: string,
+    options?: MacroGraphStoreOptions
+  ): Promise<{ duplicateNodeCount: number; excessRelCount: number }>;
 }
 /**
  * @description Graph RAG 클러스터 시블링 탐색 결과 단일 항목입니다.

--- a/src/core/ports/MacroGraphStore.ts
+++ b/src/core/ports/MacroGraphStore.ts
@@ -809,6 +809,14 @@ export interface MacroGraphStore {
     clusterId: string,
     options?: MacroGraphStoreOptions
   ): Promise<boolean>;
+
+  /**
+   * @description 연결된 MacroNode가 없는 빈 MacroCluster(Ghost Cluster)를 삭제합니다.
+   *
+   * @param userId 삭제 대상 사용자 ID
+   * @param options transaction 등 adapter 전용 옵션
+   */
+  removeEmptyClusters(userId: string, options?: MacroGraphStoreOptions): Promise<void>;
 }
 /**
  * @description Graph RAG 클러스터 시블링 탐색 결과 단일 항목입니다.

--- a/src/core/services/GraphEmbeddingService.ts
+++ b/src/core/services/GraphEmbeddingService.ts
@@ -339,6 +339,15 @@ export class GraphEmbeddingService {
   }
 
   /**
+   * 연결된 MacroNode가 없는 빈 MacroCluster(Ghost Cluster)를 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   */
+  removeEmptyClusters(userId: string) {
+    return this.graphManagementService.removeEmptyClusters(userId);
+  }
+
+  /**
    * 그래프 통계를 저장합니다.
    * @param stats - 저장할 통계 데이터. `userId`는 필수입니다.
    * @returns Promise<void>

--- a/src/core/services/GraphManagementService.ts
+++ b/src/core/services/GraphManagementService.ts
@@ -578,6 +578,47 @@ export class GraphManagementService {
     }
   }
 
+  /**
+   * 한 MacroNode에 BELONGS_TO 관계가 복수 개 누적된 경우 중복을 정리합니다.
+   *
+   * clusterId 숫자 파트가 가장 큰 클러스터(가장 최신 AI 결정)를 유지하고
+   * 나머지 BELONGS_TO 관계를 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options (선택) 트랜잭션 옵션
+   */
+  async deduplicateBelongsTo(userId: string, options?: RepoOptions): Promise<void> {
+    try {
+      this.assertUser(userId);
+      await this.repo.deduplicateBelongsTo(userId, options);
+    } catch (err: unknown) {
+      if (err instanceof AppError) throw err;
+      throw new UpstreamError('GraphService.deduplicateBelongsTo failed', { cause: String(err) });
+    }
+  }
+
+  /**
+   * dry-run 전용 — 중복 BELONGS_TO를 보유한 노드 수와 초과 관계 수를 반환합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options (선택) 트랜잭션 옵션
+   * @returns duplicateNodeCount, excessRelCount
+   */
+  async countDuplicateBelongsTo(
+    userId: string,
+    options?: RepoOptions
+  ): Promise<{ duplicateNodeCount: number; excessRelCount: number }> {
+    try {
+      this.assertUser(userId);
+      return await this.repo.countDuplicateBelongsTo(userId, options);
+    } catch (err: unknown) {
+      if (err instanceof AppError) throw err;
+      throw new UpstreamError('GraphService.countDuplicateBelongsTo failed', {
+        cause: String(err),
+      });
+    }
+  }
+
   // --- Subclusters ---
   async upsertSubcluster(subcluster: GraphSubclusterDto, options?: RepoOptions): Promise<void> {
     try {

--- a/src/core/services/GraphManagementService.ts
+++ b/src/core/services/GraphManagementService.ts
@@ -562,6 +562,22 @@ export class GraphManagementService {
     }
   }
 
+  /**
+   * 연결된 MacroNode가 없는 빈 MacroCluster(Ghost Cluster)를 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options (선택) 트랜잭션 옵션
+   */
+  async removeEmptyClusters(userId: string, options?: RepoOptions): Promise<void> {
+    try {
+      this.assertUser(userId);
+      await this.repo.removeEmptyClusters(userId, options);
+    } catch (err: unknown) {
+      if (err instanceof AppError) throw err;
+      throw new UpstreamError('GraphService.removeEmptyClusters failed', { cause: String(err) });
+    }
+  }
+
   // --- Subclusters ---
   async upsertSubcluster(subcluster: GraphSubclusterDto, options?: RepoOptions): Promise<void> {
     try {

--- a/src/infra/graph/Neo4jMacroGraphAdapter.ts
+++ b/src/infra/graph/Neo4jMacroGraphAdapter.ts
@@ -2024,6 +2024,44 @@ export class Neo4jMacroGraphAdapter implements MacroGraphStore {
       await runner.run(MACRO_GRAPH_CYPHER.cleanupEmptyClusters, { userId });
     }, options);
   }
+
+  /**
+   * @description 한 MacroNode에 BELONGS_TO 관계가 복수 개 누적된 경우 중복을 정리합니다.
+   *
+   * clusterId의 숫자 파트가 가장 큰 클러스터(가장 최신 AI 결정)를 유지하고
+   * 나머지 BELONGS_TO 관계를 모두 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options transaction 등 adapter 전용 옵션
+   */
+  async deduplicateBelongsTo(userId: string, options?: MacroGraphStoreOptions): Promise<void> {
+    await this.runWrite(async (runner) => {
+      await runner.run(MACRO_GRAPH_CYPHER.deduplicateBelongsTo, { userId });
+    }, options);
+  }
+
+  /**
+   * @description dry-run 전용 — 중복 BELONGS_TO를 보유한 노드 수와 초과 관계 수를 반환합니다.
+   *
+   * @param userId 사용자 ID
+   * @param options transaction 등 adapter 전용 옵션
+   * @returns duplicateNodeCount, excessRelCount
+   */
+  async countDuplicateBelongsTo(
+    userId: string,
+    options?: MacroGraphStoreOptions
+  ): Promise<{ duplicateNodeCount: number; excessRelCount: number }> {
+    return this.runRead(async (runner) => {
+      const result = await runner.run(MACRO_GRAPH_CYPHER.countDuplicateBelongsTo, { userId });
+      const records = result.records as unknown[];
+      if (records.length === 0) return { duplicateNodeCount: 0, excessRelCount: 0 };
+      const record = records[0] as { get(key: string): unknown };
+      return {
+        duplicateNodeCount: toJsNumber(record.get('duplicateNodeCount')),
+        excessRelCount: toJsNumber(record.get('excessRelCount')),
+      };
+    }, options);
+  }
 }
 
 

--- a/src/infra/graph/Neo4jMacroGraphAdapter.ts
+++ b/src/infra/graph/Neo4jMacroGraphAdapter.ts
@@ -2012,6 +2012,18 @@ export class Neo4jMacroGraphAdapter implements MacroGraphStore {
       return Boolean(record.get('hasNodes'));
     }, options);
   }
+
+  /**
+   * @description 연결된 MacroNode가 없는 빈 MacroCluster(Ghost Cluster)를 삭제합니다.
+   *
+   * @param userId 삭제 대상 사용자 ID
+   * @param options transaction 등 adapter 전용 옵션
+   */
+  async removeEmptyClusters(userId: string, options?: MacroGraphStoreOptions): Promise<void> {
+    await this.runWrite(async (runner) => {
+      await runner.run(MACRO_GRAPH_CYPHER.cleanupEmptyClusters, { userId });
+    }, options);
+  }
 }
 
 

--- a/src/infra/graph/cypher/macroGraph.cypher.ts
+++ b/src/infra/graph/cypher/macroGraph.cypher.ts
@@ -420,6 +420,51 @@ export const MACRO_GRAPH_CYPHER = {
   `,
 
   /**
+   * @description 한 MacroNode에 BELONGS_TO 관계가 복수 개 누적된 경우 중복을 정리합니다.
+   *
+   * clusterId 포맷이 `cluster_<숫자>` 임을 전제로, 숫자 파트가 가장 큰 클러스터(가장 최신 AI 결정)를
+   * 유지하고 나머지 BELONGS_TO 관계를 모두 DELETE 합니다.
+   * ORDER BY + collect 조합으로 내림차순 정렬된 목록의 첫 항목(keepEntry)을 보존합니다.
+   *
+   * @param userId 사용자 ID
+   * @example
+   * // 파라미터 구조 예시:
+   * // { userId: '...' }
+   */
+  deduplicateBelongsTo: `
+    MATCH (g:MacroGraph {userId: $userId})-[:HAS_NODE]->(n:MacroNode {userId: $userId})
+    WITH n
+    MATCH (n)-[r:BELONGS_TO]->(c:MacroCluster)
+    WITH n, r, c, toInteger(split(c.id, '_')[1]) AS clusterNum
+    ORDER BY clusterNum DESC
+    WITH n, collect({rel: r, clusterId: c.id}) AS entries
+    WHERE size(entries) > 1
+    WITH n, entries[0] AS keepEntry, entries[1..] AS deleteEntries
+    UNWIND deleteEntries AS toDelete
+    DELETE toDelete.rel
+  `,
+
+  /**
+   * @description dry-run 전용 — 중복 BELONGS_TO를 보유한 노드 수와 초과 관계 수를 반환합니다.
+   *
+   * 실제 DELETE 없이 `deduplicateBelongsTo` 실행 시 영향을 받을 항목만 카운트합니다.
+   *
+   * @param userId 사용자 ID
+   * @returns duplicateNodeCount (중복 노드 수), excessRelCount (삭제될 관계 수)
+   * @example
+   * // 파라미터 구조 예시:
+   * // { userId: '...' }
+   */
+  countDuplicateBelongsTo: `
+    MATCH (g:MacroGraph {userId: $userId})-[:HAS_NODE]->(n:MacroNode {userId: $userId})
+    WITH n
+    MATCH (n)-[r:BELONGS_TO]->(c:MacroCluster)
+    WITH n, count(r) AS relCount
+    WHERE relCount > 1
+    RETURN count(n) AS duplicateNodeCount, sum(relCount - 1) AS excessRelCount
+  `,
+
+  /**
    * @description MacroCluster와 소속 MacroSubcluster 사이에 HAS_SUBCLUSTER 관계를 생성합니다.
    *
    * @param userId 사용자 ID

--- a/src/infra/graph/cypher/macroGraph.cypher.ts
+++ b/src/infra/graph/cypher/macroGraph.cypher.ts
@@ -396,8 +396,27 @@ export const MACRO_GRAPH_CYPHER = {
   linkNodeBelongsToCluster: `
     UNWIND $rows AS row
     MATCH (n:MacroNode {userId: $userId, id: row.nodeId})
+    OPTIONAL MATCH (n)-[r:BELONGS_TO]->()
+    DELETE r
+    WITH n, row
     MATCH (c:MacroCluster {userId: $userId, id: row.clusterId})
     MERGE (n)-[:BELONGS_TO]->(c)
+  `,
+
+  /**
+   * @description 연결된 MacroNode가 없는 빈 MacroCluster(Ghost Cluster)를 삭제합니다.
+   *
+   * @param userId 사용자 ID
+   * @example
+   * // 파라미터 구조 예시:
+   * // {
+   * //   userId: '...',
+   * // }
+   */
+  cleanupEmptyClusters: `
+    MATCH (g:MacroGraph {userId: $userId})-[:HAS_CLUSTER]->(c:MacroCluster {userId: $userId})
+    WHERE NOT (c)<-[:BELONGS_TO]-()
+    DETACH DELETE c
   `,
 
   /**

--- a/src/workers/handlers/AddNodeResultHandler.ts
+++ b/src/workers/handlers/AddNodeResultHandler.ts
@@ -398,6 +398,10 @@ export class AddNodeResultHandler implements JobHandler {
         'AddNode persistence finished with normalized node, edge, and sourceType resolution'
       );
 
+      // 고아 클러스터(Ghost Cluster) 정리
+      // 방금 전 배치에서 노드가 다른 클러스터로 모두 이동해 비어버린 이전 클러스터를 삭제합니다.
+      await graphService.removeEmptyClusters(userId);
+
       //
       // Stat 갱신
       const stats = await graphService.getStats(userId);

--- a/tests/e2e/specs/add-node-dedup.spec.ts
+++ b/tests/e2e/specs/add-node-dedup.spec.ts
@@ -1,0 +1,380 @@
+import { describe, it, expect, beforeAll } from '@jest/globals';
+import { apiClient, getTestUserId } from '../utils/api-client';
+import { isE2eFullSuiteEnabled, e2eFullSuiteSkipReason } from '../utils/e2e-llm-env';
+import { seedTestData } from '../utils/db-seed';
+import { createNeo4jE2eDriver } from '../utils/neo4j-test-driver';
+import { MongoClient } from 'mongodb';
+
+/**
+ * AddNode 중복 노드 방지 & Ghost Cluster 정리 E2E 테스트 스펙
+ *
+ * 이 스펙은 다음 두 가지 엣지 케이스를 검증합니다:
+ *
+ * [시나리오 A] 동일 노드 재-AddNode 시 중복 렌더링 방지 (BELONGS_TO 엣지 누적 방지)
+ *   - 기존 그래프에 이미 존재하는 origId를 포함한 노드를 AddNode를 통해 다시 처리합니다.
+ *   - AI 결과로 해당 노드가 이전과 다른 clusterId에 배정되더라도,
+ *     listNodes / snapshot API에서 해당 origId에 대한 노드가 정확히 1개만 반환되어야 합니다.
+ *   - Neo4j에서 직접 BELONGS_TO 엣지 수가 1개임을 확인합니다.
+ *
+ * [시나리오 B] Ghost Cluster 자동 정리 검증
+ *   - 위 시나리오 A 이후, 노드가 이탈한 이전 클러스터(Ghost Cluster)가 Neo4j에서
+ *     자동으로 제거되었는지 검증합니다.
+ *   - listClusters API 응답에 size=0인 클러스터가 포함되지 않아야 합니다.
+ *   - Neo4j에서 직접 BELONGS_TO 연결 없는 MacroCluster 수가 0임을 확인합니다.
+ *
+ * 전제 조건:
+ * - Scenario A/B는 기존 graph-flow.spec.ts의 Scenario 1(Full Graph Generation)이
+ *   완료된 이후의 그래프 상태에서 동작합니다.
+ * - E2E_SCOPE=full + LLM 키가 있을 때만 실행됩니다.
+ *
+ * @since 2026-06-01 Neo4j BELONGS_TO 엣지 누적 버그 수정 검증을 위해 추가
+ */
+
+const MONGO_URI = process.env.MONGODB_URI || 'mongodb://localhost:27017/graphnode';
+
+/**
+ * @description E2E 환경 여부에 따라 describe를 활성화 또는 스킵합니다.
+ */
+function describeAddNodeDedup(title: string, fn: () => void): void {
+  const enabled = isE2eFullSuiteEnabled();
+  const block = enabled ? describe : describe.skip;
+  block(enabled ? title : e2eFullSuiteSkipReason() || title, fn);
+}
+
+describeAddNodeDedup('AddNode Dedup & Ghost Cluster Cleanup E2E', () => {
+  const userId = getTestUserId();
+
+  /**
+   * 테스트 시작 전 DB 시드 및 Neo4j 초기화.
+   * graph-flow.spec.ts와 동일한 seedTestData()를 재활용합니다.
+   */
+  beforeAll(async () => {
+    await seedTestData();
+
+    // Neo4j 초기화: 해당 유저의 기존 그래프 데이터 클린업
+    const neo4jDriver = createNeo4jE2eDriver();
+    const neo4jSession = neo4jDriver.session();
+    try {
+      await neo4jSession.run(
+        'MATCH (n {userId: $userId}) DETACH DELETE n',
+        { userId }
+      );
+      console.log('[Dedup E2E] Neo4j cleaned up for userId:', userId);
+    } finally {
+      await neo4jSession.close();
+      await neo4jDriver.close();
+    }
+  });
+
+  /**
+   * [사전 준비] 그래프를 먼저 생성해둡니다.
+   * 이 테스트 케이스는 graph-flow Scenario 1과 동일한 흐름으로 그래프를 생성하여
+   * 후속 시나리오 A/B의 전제 조건을 만들어줍니다.
+   */
+  it('사전 준비: 초기 그래프 생성 (Prerequisite)', async () => {
+    console.log('[Dedup E2E] Prerequisite: Generating initial graph...');
+
+    const response = await apiClient.post('/v1/graph-ai/generate', { includeSummary: false });
+    expect(response.status).toBe(202);
+    const taskId = response.data.taskId;
+    console.log(`[Dedup E2E] Graph generation task queued: ${taskId}`);
+
+    // Neo4j MacroStats CREATED 상태 폴링
+    const neo4jDriver = createNeo4jE2eDriver();
+    const neo4jSession = neo4jDriver.session();
+    let isFinished = false;
+
+    try {
+      for (let i = 0; i < 60; i++) {
+        const statsRes = await neo4jSession.run(
+          'MATCH (g:MacroGraph {userId: $userId})-[:HAS_STATS]->(st:MacroStats) RETURN st.status AS status',
+          { userId }
+        );
+        const status = statsRes.records[0]?.get('status') as string | undefined;
+
+        if (status === 'CREATED') {
+          isFinished = true;
+          console.log('[Dedup E2E] Initial graph CREATED confirmed in Neo4j.');
+          break;
+        }
+        if (status === 'NOT_CREATED') {
+          console.error('[Dedup E2E] Graph generation failed (status=NOT_CREATED).');
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+      }
+    } finally {
+      await neo4jSession.close();
+      await neo4jDriver.close();
+    }
+
+    expect(isFinished).toBe(true);
+  });
+
+  /**
+   * [시나리오 A] 동일 origId가 다른 clusterId로 재-AddNode되어도 중복 노드가 발생하지 않음을 검증
+   *
+   * 검증 방법:
+   * 1. 현재 Neo4j에서 기존 노드 중 하나(conv-e2e-123)의 origId와 clusterId를 기록합니다.
+   * 2. AddNode API를 다시 호출하여 AI 파이프라인이 해당 노드를 다른 클러스터에 배정하는 상황을 유도합니다.
+   *    (실제 AI 응답을 컨트롤할 수 없으므로, 재호출 후 결과를 Neo4j에서 직접 확인합니다.)
+   * 3. AddNode 완료 후 Neo4j에서 해당 origId에 대한 MacroNode가 정확히 1개인지 확인합니다.
+   * 4. 해당 노드의 BELONGS_TO 관계가 정확히 1개인지 Neo4j에서 직접 쿼리로 확인합니다.
+   * 5. GET /v1/graph/snapshot API 응답에서 동일 origId가 중복 등장하지 않음을 확인합니다.
+   */
+  it('Scenario A: 동일 origId 재-AddNode 후 Neo4j BELONGS_TO 엣지가 1개임을 검증', async () => {
+    console.log('[Dedup E2E] Scenario A: Re-AddNode dedup check...');
+
+    const mongoClient = new MongoClient(MONGO_URI);
+    await mongoClient.connect();
+    const db = mongoClient.db();
+
+    // 새 대화 추가 (기존 origId가 다시 처리될 수 있도록 기존 대화도 포함)
+    const newConvId = `conv-dedup-rerun-${Date.now()}`;
+    const futureMs = Date.now() + 3000;
+
+    try {
+      await db.collection('conversations').insertOne({
+        _id: newConvId,
+        ownerUserId: userId,
+        title: 'Dedup Re-run Test Chat',
+        updatedAt: futureMs,
+        createdAt: futureMs,
+      } as any);
+
+      await db.collection('messages').insertMany([
+        {
+          _id: `msg-dedup-u-${Date.now()}`,
+          conversationId: newConvId,
+          ownerUserId: userId,
+          role: 'user',
+          content: 'This is a message to trigger AddNode re-run for dedup testing.',
+          createdAt: futureMs,
+          updatedAt: futureMs,
+        },
+        {
+          _id: `msg-dedup-a-${Date.now()}`,
+          conversationId: newConvId,
+          ownerUserId: userId,
+          role: 'assistant',
+          content: 'Dedup test: Adding nodes to an existing graph should not create duplicates.',
+          createdAt: futureMs + 1000,
+          updatedAt: futureMs + 1000,
+        },
+      ] as any);
+
+      console.log(`[Dedup E2E] Inserted new conversation: ${newConvId}`);
+    } finally {
+      await mongoClient.close();
+    }
+
+    // AddNode API 재호출
+    const addNodeRes = await apiClient.post('/v1/graph-ai/add-node');
+    expect(addNodeRes.status).toBe(202);
+    console.log('[Dedup E2E] AddNode re-run queued.');
+
+    // Neo4j MacroStats UPDATED 상태 폴링
+    const neo4jDriver = createNeo4jE2eDriver();
+    const neo4jSession = neo4jDriver.session();
+    let isFinished = false;
+
+    try {
+      for (let i = 0; i < 60; i++) {
+        const statsRes = await neo4jSession.run(
+          'MATCH (g:MacroGraph {userId: $userId})-[:HAS_STATS]->(st:MacroStats) RETURN st.status AS status',
+          { userId }
+        );
+        const status = statsRes.records[0]?.get('status') as string | undefined;
+        if (status === 'UPDATED') {
+          isFinished = true;
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 10000));
+      }
+      expect(isFinished).toBe(true);
+
+      // ─── 핵심 검증 1: origId별 MacroNode 중복 체크 ───────────────────────────
+      // listNodes에서 origId 기준으로 중복이 없어야 합니다.
+      // BELONGS_TO 엣지 누적 버그가 있다면 동일 origId가 복수 rows로 반환됩니다.
+      const allNodesRes = await neo4jSession.run(
+        `MATCH (g:MacroGraph {userId: $userId})-[:HAS_NODE]->(n:MacroNode {userId: $userId})
+         WHERE n.deletedAt IS NULL
+         OPTIONAL MATCH (n)-[:BELONGS_TO]->(c:MacroCluster {userId: $userId})
+         RETURN n.id AS id, n.origId AS origId, coalesce(c.id, '') AS clusterId`,
+        { userId }
+      );
+
+      const nodesFromNeo4j = allNodesRes.records.map((r) => ({
+        id: r.get('id') as number,
+        origId: r.get('origId') as string,
+        clusterId: r.get('clusterId') as string,
+      }));
+
+      console.log(`[Dedup E2E] Total Neo4j rows returned by BELONGS_TO join: ${nodesFromNeo4j.length}`);
+
+      // origId별로 그룹핑하여 중복 여부 확인
+      const origIdGroups = new Map<string, typeof nodesFromNeo4j>();
+      for (const node of nodesFromNeo4j) {
+        const group = origIdGroups.get(node.origId) ?? [];
+        group.push(node);
+        origIdGroups.set(node.origId, group);
+      }
+
+      // 어떤 origId도 2개 이상의 row를 반환하면 안 됩니다.
+      for (const [origId, group] of origIdGroups.entries()) {
+        if (group.length > 1) {
+          console.error(
+            `[Dedup E2E] DUPLICATE DETECTED! origId="${origId}" has ${group.length} rows:`,
+            JSON.stringify(group)
+          );
+        }
+        expect(group.length).toBe(1);
+      }
+
+      console.log('[Dedup E2E] ✅ No duplicate origId found in Neo4j listNodes result.');
+
+      // ─── 핵심 검증 2: 특정 노드의 BELONGS_TO 엣지 수가 정확히 1개 ─────────────
+      // conv-e2e-123 노드를 기준으로 BELONGS_TO 엣지가 1개인지 직접 쿼리합니다.
+      const edgeCountRes = await neo4jSession.run(
+        `MATCH (g:MacroGraph {userId: $userId})-[:HAS_NODE]->(n:MacroNode {userId: $userId})
+         WHERE n.origId = $origId AND n.deletedAt IS NULL
+         MATCH (n)-[r:BELONGS_TO]->()
+         RETURN count(r) AS edgeCount`,
+        { userId, origId: 'conv-e2e-123' }
+      );
+
+      if (edgeCountRes.records.length > 0) {
+        const edgeCount = (edgeCountRes.records[0].get('edgeCount') as { toNumber(): number } | number);
+        const edgeCountNum = typeof edgeCount === 'number' ? edgeCount : edgeCount.toNumber();
+        console.log(`[Dedup E2E] BELONGS_TO edge count for conv-e2e-123: ${edgeCountNum}`);
+        // BELONGS_TO 엣지가 1개를 초과하면 중복 버그가 있는 것
+        expect(edgeCountNum).toBeLessThanOrEqual(1);
+      } else {
+        console.log('[Dedup E2E] conv-e2e-123 not found in Neo4j (may have been excluded by AI).');
+      }
+
+      // ─── 핵심 검증 3: API snapshot 응답에서 origId 중복 없음 ────────────────────
+      const snapshotRes = await apiClient.get('/v1/graph/snapshot');
+      expect(snapshotRes.status).toBe(200);
+
+      const snapshotNodes = (snapshotRes.data?.nodes ?? []) as Array<{
+        id: number;
+        origId: string;
+        clusterId: string;
+      }>;
+
+      const snapshotOrigIds = snapshotNodes.map((n) => n.origId);
+      const snapshotOrigIdSet = new Set(snapshotOrigIds);
+
+      console.log(
+        `[Dedup E2E] Snapshot API nodes: ${snapshotNodes.length} (unique origIds: ${snapshotOrigIdSet.size})`
+      );
+
+      // origId 기준 중복이 없어야 합니다.
+      expect(snapshotNodes.length).toBe(snapshotOrigIdSet.size);
+
+      console.log('[Dedup E2E] ✅ Snapshot API returned no duplicate origIds.');
+    } finally {
+      await neo4jSession.close();
+      await neo4jDriver.close();
+    }
+  });
+
+  /**
+   * [시나리오 B] AddNode 완료 후 연결된 노드가 없는 Ghost Cluster가 Neo4j에 남아 있지 않음을 검증
+   *
+   * 검증 방법:
+   * 1. Neo4j에서 HAS_CLUSTER로 연결된 모든 MacroCluster를 조회합니다.
+   * 2. 각 클러스터에 대해 BELONGS_TO로 연결된 활성 MacroNode 수를 집계합니다.
+   * 3. size=0인 클러스터(Ghost Cluster)가 존재하지 않아야 합니다.
+   * 4. GET /v1/graph/clusters API 응답의 모든 클러스터 size가 1 이상이어야 합니다.
+   */
+  it('Scenario B: AddNode 완료 후 Ghost Cluster(size=0)가 Neo4j에 존재하지 않음을 검증', async () => {
+    console.log('[Dedup E2E] Scenario B: Ghost Cluster cleanup check...');
+
+    const neo4jDriver = createNeo4jE2eDriver();
+    const neo4jSession = neo4jDriver.session();
+
+    try {
+      // ─── 핵심 검증 1: Neo4j에서 직접 Ghost Cluster 조회 ─────────────────────
+      // 연결된 노드가 없는 클러스터 목록 쿼리
+      const ghostClusterRes = await neo4jSession.run(
+        `MATCH (g:MacroGraph {userId: $userId})-[:HAS_CLUSTER]->(c:MacroCluster {userId: $userId})
+         WHERE NOT (c)<-[:BELONGS_TO]-()
+         RETURN c.id AS clusterId, c.name AS clusterName`,
+        { userId }
+      );
+
+      const ghostClusters = ghostClusterRes.records.map((r) => ({
+        clusterId: r.get('clusterId') as string,
+        clusterName: r.get('clusterName') as string,
+      }));
+
+      if (ghostClusters.length > 0) {
+        console.error(
+          `[Dedup E2E] GHOST CLUSTERS DETECTED (${ghostClusters.length}):`,
+          JSON.stringify(ghostClusters)
+        );
+      } else {
+        console.log('[Dedup E2E] ✅ No ghost clusters found in Neo4j.');
+      }
+
+      // Ghost Cluster가 0개여야 합니다.
+      expect(ghostClusters.length).toBe(0);
+
+      // ─── 핵심 검증 2: 전체 클러스터의 size 집계 검증 ────────────────────────
+      // 모든 클러스터의 BELONGS_TO count를 확인하여 size=0이 없음을 재차 확인합니다.
+      const clusterSizesRes = await neo4jSession.run(
+        `MATCH (g:MacroGraph {userId: $userId})-[:HAS_CLUSTER]->(c:MacroCluster {userId: $userId})
+         OPTIONAL MATCH (n:MacroNode {userId: $userId})-[:BELONGS_TO]->(c)
+         WHERE n.deletedAt IS NULL
+         RETURN c.id AS clusterId, count(DISTINCT n) AS size`,
+        { userId }
+      );
+
+      const clusterSizes = clusterSizesRes.records.map((r) => ({
+        clusterId: r.get('clusterId') as string,
+        size: (r.get('size') as { toNumber(): number } | number),
+      }));
+
+      console.log(`[Dedup E2E] Total clusters in Neo4j: ${clusterSizes.length}`);
+
+      for (const cluster of clusterSizes) {
+        const size = typeof cluster.size === 'number' ? cluster.size : cluster.size.toNumber();
+        if (size === 0) {
+          console.error(`[Dedup E2E] GHOST CLUSTER: clusterId=${cluster.clusterId} has size=0`);
+        }
+        expect(size).toBeGreaterThan(0);
+      }
+
+      console.log('[Dedup E2E] ✅ All clusters have at least 1 connected node.');
+
+      // ─── 핵심 검증 3: API clusters 엔드포인트 응답의 size 검증 ────────────────
+      // GET /v1/graph/clusters API가 size=0인 클러스터를 반환하지 않아야 합니다.
+      const clustersApiRes = await apiClient.get('/v1/graph/clusters');
+      expect(clustersApiRes.status).toBe(200);
+
+      const apiClusters = (clustersApiRes.data ?? []) as Array<{
+        id: string;
+        name: string;
+        size: number;
+      }>;
+
+      console.log(`[Dedup E2E] Clusters from API: ${apiClusters.length}`);
+
+      for (const cluster of apiClusters) {
+        if (cluster.size === 0) {
+          console.error(
+            `[Dedup E2E] API returned ghost cluster: id=${cluster.id}, name="${cluster.name}", size=${cluster.size}`
+          );
+        }
+        expect(cluster.size).toBeGreaterThan(0);
+      }
+
+      console.log('[Dedup E2E] ✅ API /v1/graph/clusters returned no ghost clusters.');
+    } finally {
+      await neo4jSession.close();
+      await neo4jDriver.close();
+    }
+  });
+});

--- a/tests/unit/Neo4jMacroGraphAdapter.spec.ts
+++ b/tests/unit/Neo4jMacroGraphAdapter.spec.ts
@@ -409,4 +409,21 @@ describe('Neo4jMacroGraphAdapter', () => {
       expect(session2.close).toHaveBeenCalledTimes(1);
     });
   });
+  describe('removeEmptyClusters', () => {
+    it('write session에서 cleanupEmptyClusters Cypher를 실행한다', async () => {
+      const tx = makeMockTx();
+      const session = {
+        executeWrite: jest.fn().mockImplementation(async (fn: (t: typeof tx) => Promise<void>) => fn(tx)),
+        close: jest.fn().mockResolvedValue(undefined),
+      };
+      const driver = { session: jest.fn().mockReturnValue(session) };
+      (getNeo4jDriver as jest.Mock).mockReturnValue(driver);
+
+      const adapter = new Neo4jMacroGraphAdapter();
+      await adapter.removeEmptyClusters('user1');
+
+      const calledQuery = (tx.run as jest.Mock).mock.calls[0][0] as string;
+      expect(calledQuery).toContain(MACRO_GRAPH_CYPHER.cleanupEmptyClusters);
+    });
+  });
 });

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "dist"
+  },
+  "include": ["scripts/**/*", "src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## 배경 및 문제 상황
AddNode 수행 후 FE에서 동일한 origId·nodeTitle을 가진 노드가
서로 다른 clusterId로 2개씩 쌍을 이루며 렌더링되는 현상 발생.

## 원인
Neo4j listNodes 쿼리는 OPTIONAL MATCH (n)-[:BELONGS_TO]->(c) 구문으로 노드-클러스터 관계를 JOIN 방식으로 조회한다.
AddNode가 반복 수행될 때 노드의 클러스터가 변경되면 기존 BELONGS_TO
관계를 삭제하지 않고 새 관계를 MERGE로 추가만 했기 때문에,
하나의 MacroNode가 복수 개의 BELONGS_TO 엣지를 갖게 된다.
이 상태에서 listNodes를 호출하면 동일 노드에 대해 Cartesian Product로 클러스터 수만큼의 행이 반환되어 FE가 중복 노드로 인식하게 된다.
또한 노드가 이탈한 이전 클러스터는 삭제되지 않아 size=0인
Ghost Cluster로 Neo4j에 방치된다.

## 해결 방안
- linkNodeBelongsToCluster Cypher 수정: 새 클러스터 관계 MERGE 전, 기존 BELONGS_TO 관계 전체 DELETE 처리. → 노드는 항상 단 하나의 클러스터에만 연결됨을 보장.
- cleanupEmptyClusters Cypher 추가: AddNodeResultHandler의 모든 청크 upsert 완료 직후, BELONGS_TO로 연결된 노드가 없는 MacroCluster를 일괄 DETACH DELETE.
- 검증: Neo4jMacroGraphAdapter 유닛 테스트 및 E2E 스펙 추가.